### PR TITLE
fix `read_pandas` fn for object-like attributes

### DIFF
--- a/src/jaklas/read.py
+++ b/src/jaklas/read.py
@@ -66,13 +66,16 @@ def read_header(path) -> Header:
 def read_pandas(path, *, offset=None, xyz_dtype="d", other_dims=None, ignore_missing_dims=False):
     import pandas as pd
 
-    return pd.DataFrame(
-        read(
-            path,
-            offset=offset,
-            combine_xyz=False,
-            xyz_dtype=xyz_dtype,
-            other_dims=other_dims,
-            ignore_missing_dims=ignore_missing_dims,
-        )
+    data = read(
+        path,
+        offset=offset,
+        combine_xyz=False,
+        xyz_dtype=xyz_dtype,
+        other_dims=other_dims,
+        ignore_missing_dims=ignore_missing_dims,
     )
+
+    # laspy is reading some attributes as type object instead of array
+    data = {k: np.ascontiguousarray(v) for k, v in data.items()}
+
+    return pd.DataFrame(data)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -49,6 +49,7 @@ def test_read_pandas():
     assert len(df["x"]) == 71
     assert "x" in df and "y" in df and "z" in df
     assert "gps_time" in df and "intensity" in df
+    assert len(df.classification) == 71 and df.classification.dtype == "uint8"
 
 
 def test_read_dtype():


### PR DESCRIPTION
fix #16 