### PR TITLE
Adjust automatic scale factor to leave more of a gap

### DIFF
--- a/src/jaklas/write.py
+++ b/src/jaklas/write.py
@@ -169,7 +169,7 @@ def _min_max_offset(xyz: List[np.ndarray]) -> Tuple[Tuple[float]]:
 
 
 def _get_scale(minimums, maximums, offset) -> Tuple[float]:
-    max_long = np.iinfo(np.int32).max - 1
+    max_long = np.iinfo(np.int32).max - 8
 
     offsetted_max_ranges = np.max(
         [np.abs(minimums - offset), np.abs(maximums - offset)], axis=0


### PR DESCRIPTION
I came across some a subtle issue concerning point clouds being slightly corrupted by the LasZip LAZ writer.

As it turned out these particular clouds were output by this Python library.
Since the data had been "tiled", lots of points along axis-aligned bounding box boundaries.
What we observed is some of these points on the AAB boundary "flipping" across to the opposite side.

In this particular workflow there are two steps that potentially do round-off of XYZ positions:
- XYZ position computed from integer and double-precision offset and scale factor, but stored as float
- The LasZip LAZ writer internally _rounds_ to the nearest integer, even if that's out of range for int32

```
#define I32_QUANTIZE(n) (((n) >= 0) ? (I32)((n)+0.5) : (I32)((n)-0.5))
```

So the rationale for this change is to reduce precision a little bit to avoid having points near the bounding box boundary too close to the numerical range of int32.