### PR TITLE
Avoid point format auto-detection when point_format=0 is specified

### DIFF
--- a/src/jaklas/write.py
+++ b/src/jaklas/write.py
@@ -63,7 +63,7 @@ def write(
     standard_dimensions = point_formats.standard_dimensions | {"xyz", "XYZ"}
     extra_dimensions = sorted(set(point_data) - standard_dimensions)
 
-    if not point_format:
+    if point_format is None:
         point_format = point_formats.best_point_format(point_data, extra_dimensions)
 
     if point_format not in point_formats.supported_point_formats:


### PR DESCRIPTION
If you pass an explicit point_format=0 to jaklas.write, it would trigger automatic point detection.
Replaced falsy detection with is None detection to fix that.